### PR TITLE
Add dependabot configuration for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Based on https://github.com/tiangolo/fastapi/blob/master/.github/dependabot.yml. FastAPI also only has a pyproject.toml (no setup.py), so this should work.

Dependabot has to be enabled by an admin though.

Dependabot won't do much now since we don't constrain the versions of the dependencies, but we might do so in the future.