### PR TITLE
fix datetme_tz.from_datetime assertion error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.0.2
+-----
+
+Released 2022-11-28.
+
+**Breaking changes**:
+
+- None.
+
+Release highlights:
+
+- Fix bug in `datetime_tz.from_datetime()` where if the input datetime is itself a different instance of `datetime_tz` than the class reparsing it an `AssertionError` would be raised.
+
 1.0.1
 -----
 

--- a/tests/instantiation_test.py
+++ b/tests/instantiation_test.py
@@ -75,6 +75,33 @@ def test_datetime_tz_from_naive_datetime() -> None:
         datetime_tz.from_datetime(input_dt)
 
 
+@parameterized.expand(
+    [
+        (
+            datetime_utc,
+            10,
+            datetime_utc(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo('UTC')),
+        ),
+        (
+            datetime_cet,
+            10,
+            datetime_cet(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo('CET')),
+        ),
+        (
+            datetime_cet,
+            11,
+            datetime_utc(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo('UTC')),
+        ),
+    ]
+)
+def test_from_datetime_tz(
+    expected_dt_class: DatetimeT, expected_hour: int, input_dt: DateTimeTzT
+) -> None:
+    reparsed = expected_dt_class.from_datetime(input_dt)
+    assert isinstance(reparsed, expected_dt_class)
+    assert reparsed.hour == expected_hour
+
+
 def test_datetime_tz_now() -> None:
     with pytest.raises(
         DatetimeTzError,


### PR DESCRIPTION
Fix a bug where the following leads to an `AssertionError`:

```py
datetime_cet.from_datetime(datetime_utc.now())
```

The issue is, that `astimezone` will try to instantiate a `datetime_utc` in the `CET` timezone, which we don't allow. Because of this, if the input datetime to `from_datetime` is itself an instance of `datetime_tz` we need to create a regular datetime object in order to change the timezone.

This is strictly not necessary if one were to do:

```py
datetime_utc.from_datetime(datetime_utc.now())
```
but making the conditional more complex to spare some processing power on a usecase that doesn't make much sense in the first place (why would you reparse a `datetime_utc` into a `datetime_utc`?), I opted to not check for this.