### PR TITLE
include py.typed in release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.0.3
+-----
+
+Released 2022-11-29.
+
+**Breaking changes**:
+
+- None.
+
+Release highlights:
+
+- Included `py.typed` in packaged release
+
 1.0.2
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ Homepage = 'https://github.com/channable/heliclockter'
 [tool.setuptools.dynamic]
 version = {attr = 'heliclockter.__version__'}
 
+[tool.setuptools.package-data]
+heliclockter = ['py.typed']
+
 [project.optional-dependencies]
 all = ['bandit', 'black', 'mypy', 'pydantic', 'pylint', 'pytest', 'parameterized', 'toml']
 

--- a/src/heliclockter/__init__.py
+++ b/src/heliclockter/__init__.py
@@ -32,7 +32,7 @@ timedelta = _datetime.timedelta
 
 tz_local = cast(ZoneInfo, _datetime.datetime.now().astimezone().tzinfo)
 
-__version__ = '1.0.2'
+__version__ = '1.0.3'
 
 
 DateTimeTzT = TypeVar('DateTimeTzT', bound='datetime_tz')


### PR DESCRIPTION
Due to an oversight, `py.typed` was not included in the packaged module, so `mypy` could not actually check it. This PR should fix that.