### PR TITLE
Pydantic v2 migration

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -26,7 +26,7 @@ blocks:
             - "python3.9 -m pytest tests"
             # Test without pydantic as well
             - "python3.9 -m pip uninstall pydantic -y"
-            - "python3.9 -m pytest tests --ignore ./tests/pydantic_parsing_test.py"
+            - "python3.9 -m pytest tests --ignore-glob \"./tests/pydantic_*.py\""
 
         - name: "Unit tests 3.10"
           commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+1.1.0
+-----
+
+Released 2023-10-02.
+
+**Breaking changes**:
+
+- None
+
+Release highlights:
+
+- Heliclockter now supports Pydantic v2. See the
+  [migration guide](https://docs.pydantic.dev/latest/migration/) on how to migrate to Pydantic v2.
+  Pydantic v1 is still supported for now. 
+
 1.0.4
 -----
 

--- a/src/heliclockter/__init__.py
+++ b/src/heliclockter/__init__.py
@@ -16,12 +16,23 @@ from typing import (
 from zoneinfo import ZoneInfo
 
 # We don't require pydantic as a dependency, but add validate logic if it exists.
+# `parse_datetime` doesn't exist in Pydantic v2, so `PYDANTIC_V1_AVAILABLE is False` when
+# pydantic v2 is installed.
 try:
     from pydantic.datetime_parse import parse_datetime
 
-    PYDANTIC_AVAILABLE = True
+    PYDANTIC_V1_AVAILABLE = True
 except ImportError:
-    PYDANTIC_AVAILABLE = False
+    PYDANTIC_V1_AVAILABLE = False
+
+try:
+    from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+    from pydantic_core import CoreSchema, core_schema
+    from pydantic.json_schema import JsonSchemaValue
+
+    PYDANTIC_V2_AVAILABLE = True
+except ImportError:
+    PYDANTIC_V2_AVAILABLE = False
 
 
 # `date` and `timedelta` are exposed for your convenience in case this module is used in combination
@@ -32,7 +43,7 @@ timedelta = _datetime.timedelta
 
 tz_local = cast(ZoneInfo, _datetime.datetime.now().astimezone().tzinfo)
 
-__version__ = '1.0.4'
+__version__ = '1.1.0'
 
 
 DateTimeTzT = TypeVar('DateTimeTzT', bound='datetime_tz')
@@ -90,7 +101,7 @@ class datetime_tz(_datetime.datetime):
 
             self.assert_aware_datetime(self)
 
-    if PYDANTIC_AVAILABLE:
+    if PYDANTIC_V1_AVAILABLE:
 
         @classmethod
         def __get_validators__(cls) -> Iterator[Callable[[Any], Optional[datetime_tz]]]:
@@ -103,6 +114,33 @@ class datetime_tz(_datetime.datetime):
 
             dt = v if isinstance(v, _datetime.datetime) else parse_datetime(v)
             return cls.from_datetime(dt)
+
+    elif PYDANTIC_V2_AVAILABLE:
+
+        @classmethod
+        def __get_pydantic_core_schema__(cls, _: Any, __: GetCoreSchemaHandler) -> CoreSchema:
+            from_datetime_schema = core_schema.chain_schema(
+                [
+                    core_schema.datetime_schema(),
+                    core_schema.no_info_plain_validator_function(cls.from_datetime),
+                ]
+            )
+
+            return core_schema.json_or_python_schema(
+                json_schema=from_datetime_schema,
+                python_schema=core_schema.union_schema(
+                    [
+                        core_schema.is_instance_schema(datetime_tz),
+                        from_datetime_schema,
+                    ]
+                ),
+            )
+
+        @classmethod
+        def __get_pydantic_json_schema__(
+            cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        ) -> JsonSchemaValue:
+            return handler(core_schema.datetime_schema())
 
     @classmethod
     def from_datetime(cls: Type[DateTimeTzT], dt: _datetime.datetime) -> DateTimeTzT:

--- a/tests/pydantic_parsing_test.py
+++ b/tests/pydantic_parsing_test.py
@@ -93,13 +93,13 @@ TestModelT = Union[DatetimeTZModel, DatetimeUTCModel, DatetimeCETModel]
     ]
 )
 def test_datetime_parsing(test_str: str, expectation: DateTimeTzT, model: TestModelT) -> None:
-    parsed_model = model.parse_obj({'dt': test_str})
+    parsed_model = model.model_validate({'dt': test_str})
     assert isinstance(parsed_model.dt, type(expectation))
     assert parsed_model.dt == expectation
 
 
 def test_datetime_local_parsing() -> None:
-    parsed_model = DatetimeLocalModel.parse_obj({'dt': '2021-01-10T10:00:00-04:00'})
+    parsed_model = DatetimeLocalModel.model_validate({'dt': '2021-01-10T10:00:00-04:00'})
     assert isinstance(parsed_model.dt, datetime_local)
 
 
@@ -116,12 +116,12 @@ def test_parse_datetime_utc_as_datetime_tz() -> None:
 
 def test_parse_datetime_tz_without_timezone() -> None:
     with pytest.raises(ValidationError):
-        DatetimeTZModel.parse_obj({'dt': '2021-01-10T10:00:00'})
+        DatetimeTZModel.model_validate({'dt': '2021-01-10T10:00:00'})
 
 
 def test_parse_datetime_instance() -> None:
     dt = datetime(2021, 1, 10, 10, 0, 0, tzinfo=ZoneInfo('UTC'))
-    DatetimeTZModel.parse_obj({'dt': dt})
+    DatetimeTZModel.model_validate({'dt': dt})
 
     parsed_tz_model = DatetimeTZModel(dt=dt)  # type: ignore[arg-type]
     assert isinstance(parsed_tz_model.dt, datetime_tz)

--- a/tests/pydantic_serialization_test.py
+++ b/tests/pydantic_serialization_test.py
@@ -1,0 +1,15 @@
+from zoneinfo import ZoneInfo
+
+from pydantic import BaseModel
+
+from heliclockter import datetime_tz
+
+
+class DatetimeTZModel(BaseModel):
+    dt: datetime_tz
+
+
+def test_pydantic_serialization() -> None:
+    obj = DatetimeTZModel(dt=datetime_tz(2021, 1, 10, 10, 0, tzinfo=ZoneInfo('UTC')))
+
+    assert obj.model_dump_json() == '{"dt":"2021-01-10T10:00:00Z"}'


### PR DESCRIPTION
fixes https://github.com/channable/heliclockter/issues/7

Makes heliclockter compatible with both pydantic v1 and v2.
