### PR TITLE
Update type ignores for `parameterized`

### DIFF
--- a/tests/assertion_test.py
+++ b/tests/assertion_test.py
@@ -2,7 +2,7 @@ import datetime
 from zoneinfo import ZoneInfo
 
 import pytest
-from parameterized import parameterized  # type: ignore[import]
+from parameterized import parameterized  # type: ignore[import-untyped]
 
 from heliclockter import datetime_tz, timedelta, tz_local
 

--- a/tests/instantiation_test.py
+++ b/tests/instantiation_test.py
@@ -4,7 +4,7 @@ from typing import Optional, Type, Union
 from zoneinfo import ZoneInfo
 
 import pytest
-from parameterized import parameterized  # type: ignore[import]
+from parameterized import parameterized  # type: ignore[import-untyped]
 
 from heliclockter import (
     DateTimeTzT,

--- a/tests/pydantic_parsing_test.py
+++ b/tests/pydantic_parsing_test.py
@@ -3,7 +3,7 @@ from typing import Union
 from zoneinfo import ZoneInfo
 
 import pytest
-from parameterized import parameterized  # type: ignore[import]
+from parameterized import parameterized  # type: ignore[import-untyped]
 from pydantic import BaseModel, ValidationError
 
 from heliclockter import DateTimeTzT, datetime_local, datetime_tz, datetime_utc, timedelta

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -1,6 +1,6 @@
 from zoneinfo import ZoneInfo
 
-from parameterized import parameterized  # type: ignore[import]
+from parameterized import parameterized  # type: ignore[import-untyped]
 
 from heliclockter import datetime_tz, datetime_utc
 


### PR DESCRIPTION
Fixes the following errors https://channable.semaphoreci.com/jobs/c82a5c8b-8561-4700-a4bc-5eb93192a365#L310-L315

I think a new release bump is unnecessary, since this contains no runtime change and I hope to merge https://github.com/channable/heliclockter/pull/10 soon which already does a version bump.