### PR TITLE
Support pydantic v1 module in pydantic v2 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.2.0
+-----
+
+Released 2023-11-16.
+
+**Breaking changes**:
+
+- None
+
+Release highlights:
+
+- Adds support for using the `pydantic.v1` module from pydantic v2 for backward compatibility.
+
 1.1.0
 -----
 

--- a/src/heliclockter/__init__.py
+++ b/src/heliclockter/__init__.py
@@ -29,6 +29,7 @@ try:
     from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
     from pydantic_core import CoreSchema, core_schema
     from pydantic.json_schema import JsonSchemaValue
+    from pydantic.v1.datetime_parse import parse_datetime
 
     PYDANTIC_V2_AVAILABLE = True
 except ImportError:
@@ -43,7 +44,7 @@ timedelta = _datetime.timedelta
 
 tz_local = cast(ZoneInfo, _datetime.datetime.now().astimezone().tzinfo)
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'
 
 
 DateTimeTzT = TypeVar('DateTimeTzT', bound='datetime_tz')
@@ -101,7 +102,7 @@ class datetime_tz(_datetime.datetime):
 
             self.assert_aware_datetime(self)
 
-    if PYDANTIC_V1_AVAILABLE:
+    if PYDANTIC_V1_AVAILABLE or PYDANTIC_V2_AVAILABLE:
 
         @classmethod
         def __get_validators__(cls) -> Iterator[Callable[[Any], Optional[datetime_tz]]]:
@@ -115,7 +116,7 @@ class datetime_tz(_datetime.datetime):
             dt = v if isinstance(v, _datetime.datetime) else parse_datetime(v)
             return cls.from_datetime(dt)
 
-    elif PYDANTIC_V2_AVAILABLE:
+    if PYDANTIC_V2_AVAILABLE:
 
         @classmethod
         def __get_pydantic_core_schema__(cls, _: Any, __: GetCoreSchemaHandler) -> CoreSchema:

--- a/tests/pydantic_v1_parsing_test.py
+++ b/tests/pydantic_v1_parsing_test.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timezone
+from typing import Union
+from zoneinfo import ZoneInfo
+
+import pytest
+from parameterized import parameterized  # type: ignore[import-untyped]
+from pydantic.v1 import BaseModel, ValidationError
+
+from heliclockter import DateTimeTzT, datetime_local, datetime_tz, datetime_utc, timedelta
+
+from tests.shared import datetime_cet
+
+
+class DatetimeTZModel(BaseModel):
+    dt: datetime_tz
+
+
+class DatetimeUTCModel(BaseModel):
+    dt: datetime_utc
+
+
+class DatetimeCETModel(BaseModel):
+    dt: datetime_cet
+
+
+class DatetimeLocalModel(BaseModel):
+    dt: datetime_local
+
+
+class DatetimeDefaultObject(BaseModel):
+    dt_now: datetime_tz = datetime_utc.now()
+    dt: str = datetime_utc.future(days=120).isoformat()
+
+
+TestModelT = Union[DatetimeTZModel, DatetimeUTCModel, DatetimeCETModel]
+
+
+@parameterized.expand(
+    [
+        # UTC tests
+        (
+            '2021-01-10T10:00:00',
+            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('UTC')),
+            DatetimeUTCModel,
+        ),
+        (
+            '2021-01-10T10:00:00+04:00',
+            datetime_utc(2021, 1, 10, 6, 00, 00, tzinfo=ZoneInfo('UTC')),
+            DatetimeUTCModel,
+        ),
+        (
+            '2021-01-10T10:00:00+00:00',
+            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('UTC')),
+            DatetimeUTCModel,
+        ),
+        (
+            '2021-01-10T10:00:00-04:00',
+            datetime_utc(2021, 1, 10, 14, 00, 00, tzinfo=ZoneInfo('UTC')),
+            DatetimeUTCModel,
+        ),
+        # TZ tests
+        (
+            '2021-01-10T10:00:00+04:00',
+            datetime_tz(2021, 1, 10, 10, 0, tzinfo=timezone(timedelta(hours=4))),
+            DatetimeTZModel,
+        ),
+        (
+            '2021-01-10T10:00:00-04:00',
+            datetime_tz(2021, 1, 10, 10, 0, tzinfo=timezone(timedelta(hours=-4))),
+            DatetimeTZModel,
+        ),
+        # CET tests
+        (
+            '2021-01-10T10:00:00',
+            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('CET')),
+            DatetimeCETModel,
+        ),
+        (
+            '2021-01-10T10:00:00+04:00',
+            datetime_cet(2021, 1, 10, 7, 00, 00, tzinfo=ZoneInfo('CET')),
+            DatetimeCETModel,
+        ),
+        (
+            '2021-01-10T10:00:00+00:00',
+            datetime_cet(2021, 1, 10, 11, 00, 00, tzinfo=ZoneInfo('CET')),
+            DatetimeCETModel,
+        ),
+        (
+            '2021-01-10T10:00:00-04:00',
+            datetime_cet(2021, 1, 10, 15, 00, 00, tzinfo=ZoneInfo('CET')),
+            DatetimeCETModel,
+        ),
+    ]
+)
+def test_datetime_parsing(test_str: str, expectation: DateTimeTzT, model: TestModelT) -> None:
+    parsed_model = model.parse_obj({'dt': test_str})
+    assert isinstance(parsed_model.dt, type(expectation))
+    assert parsed_model.dt == expectation
+
+
+def test_datetime_local_parsing() -> None:
+    parsed_model = DatetimeLocalModel.parse_obj({'dt': '2021-01-10T10:00:00-04:00'})
+    assert isinstance(parsed_model.dt, datetime_local)
+
+
+def test_create_default_pydantic_field() -> None:
+    obj = DatetimeDefaultObject()
+    assert obj.dt
+    assert obj.dt_now
+
+
+def test_parse_datetime_utc_as_datetime_tz() -> None:
+    obj = DatetimeDefaultObject(dt_now=datetime_utc.now())
+    assert isinstance(obj.dt_now, datetime_tz)
+
+
+def test_parse_datetime_tz_without_timezone() -> None:
+    with pytest.raises(ValidationError):
+        DatetimeTZModel.parse_obj({'dt': '2021-01-10T10:00:00'})
+
+
+def test_parse_datetime_instance() -> None:
+    dt = datetime(2021, 1, 10, 10, 0, 0, tzinfo=ZoneInfo('UTC'))
+    DatetimeTZModel.parse_obj({'dt': dt})
+
+    parsed_tz_model = DatetimeTZModel(dt=dt)  # type: ignore[arg-type]
+    assert isinstance(parsed_tz_model.dt, datetime_tz)
+
+    parsed_utc_model = DatetimeUTCModel(dt=dt)  # type: ignore[arg-type]
+    assert isinstance(parsed_utc_model.dt, datetime_utc)


### PR DESCRIPTION
Adds support for using the `pydantic.v1` module of pydantic v2 for backwards compatibility. This makes migrations of pydantic v1 to v2 more gradual and easier.

Needs https://github.com/channable/heliclockter/pull/9 for CI to pass

Includes a bump to 1.2.0