### PR TITLE
Add python 3.12 support

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -36,7 +36,12 @@ blocks:
         - name: "Unit tests 3.11"
           commands:
             # Semaphore does not have python3.11, so we run the tests using a Dockerfile
-            - "sudo docker build -t src . && sudo docker run src"
+            - "sudo docker build --build-arg PYTHON_VERSION=3.11.0 -t py311 . && sudo docker run py311"
+
+        - name: "Unit tests 3.12"
+          commands:
+            # Semaphore does not have python3.12, so we run the tests using a Dockerfile
+            - "sudo docker build --build-arg PYTHON_VERSION=3.12.1 -t py312 . && sudo docker run py312"
 
         - name: "Typing"
           commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.3.0
+-----
+
+Released 2024-01-08.
+
+**Breaking changes**:
+
+- None
+
+Release highlights:
+
+- Adds support for python 3.12.
+
 1.2.0
 -----
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11.0
+ARG PYTHON_VERSION=3.12.1
+FROM python:${PYTHON_VERSION}
 
 WORKDIR /usr/src/app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Typing :: Typed'
 ]
 dependencies = []


### PR DESCRIPTION
Adds python 3.12 support

This PR uses Docker's [build-args](https://docs.docker.com/build/guide/build-args/) to be able to parameterize the docker build for different Python versions.