### PR TITLE
add fold to constructor

### DIFF
--- a/src/heliclockter/__init__.py
+++ b/src/heliclockter/__init__.py
@@ -77,6 +77,7 @@ class datetime_tz(_datetime.datetime):
             microsecond: int = 0,
             *,
             tzinfo: _datetime.tzinfo,
+            fold: int = 0,
         ) -> None:
             pass
 
@@ -92,6 +93,7 @@ class datetime_tz(_datetime.datetime):
             second: int = 0,
             microsecond: int = 0,
             tzinfo: _datetime.tzinfo = None,
+            fold: int = 0,
         ) -> None:
             msg = f'{self.__class__} must have a timezone'
             assert tzinfo is not None and self.tzinfo is not None, msg
@@ -167,6 +169,7 @@ class datetime_tz(_datetime.datetime):
                     second=dt.second,
                     microsecond=dt.microsecond,
                     tzinfo=dt.tzinfo,
+                    fold=dt.fold,
                 ).astimezone(tz=assumed_tz)
 
             else:
@@ -182,6 +185,7 @@ class datetime_tz(_datetime.datetime):
             second=dt.second,
             microsecond=dt.microsecond,
             tzinfo=dt.tzinfo,  # type: ignore[arg-type]
+            fold=dt.fold,
         )
 
     @classmethod
@@ -271,6 +275,7 @@ class datetime_tz(_datetime.datetime):
             second=self.second,
             microsecond=self.microsecond,
             tzinfo=self.tzinfo,  # type: ignore[arg-type]
+            fold=self.fold,
         )
 
 

--- a/tests/instantiation_test.py
+++ b/tests/instantiation_test.py
@@ -272,3 +272,10 @@ def test_future_and_past_no_tz() -> None:
 
     with pytest.raises(DatetimeTzError, match=error_msg):
         datetime_tz.past(days=2)
+
+
+@parameterized.expand([(0,), (1,)])
+def test_fold(fold: int) -> None:
+    dt = datetime_tz(2023, 10, 29, 2, 30, fold=fold, tzinfo=ZoneInfo("Europe/Berlin"))
+    iso_offset = "+01:00" if fold == 1 else '+02:00'
+    assert dt.isoformat().endswith(iso_offset)


### PR DESCRIPTION
xref: https://github.com/channable/heliclockter/issues/12

As pointed out by @ariebovenberg not having `fold` in the constructor removes functionality seemingly without reason