### PR TITLE
Replace black with ruff

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -55,8 +55,7 @@ blocks:
 
         - name: "Style"
           commands:
-            - "python3.10 -m black --check ."
-            - "python3.10 -m isort --check datetime_tz tests"
+            - "python3.10 -m ruff check ."
 
         - name: "Security"
           commands:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+1.3.2
+-----
+
+Released 2025-07-30.
+
+**Breaking changes**:
+
+- None
+
+Release highlights:
+
+- Replace Ruff with Black and reformat codebase
+
 1.3.1
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 1.3.2
 -----
 
-Released 2025-07-30.
+Released 2025-08-01.
 
 **Breaking changes**:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,24 +36,39 @@ version = {attr = 'heliclockter.__version__'}
 heliclockter = ['py.typed']
 
 [project.optional-dependencies]
-all = ['bandit', 'black', 'mypy', 'pydantic', 'pylint', 'pytest', 'parameterized', 'toml']
+all = ['bandit', 'ruff', 'mypy', 'pydantic', 'pylint', 'pytest', 'parameterized', 'toml']
 
-[tool.black]
-target-version = ['py39']
+[tool.ruff]
 line-length = 100
-skip-string-normalization = true
-exclude = '(^\..+|local_cache|venv)'
-workers = 4
+output-format = "full"
+respect-gitignore = false
+show-fixes = true
+target-version = "py313"
+exclude = ["venv"]
 
-[tool.isort]
-profile = 'black'
-multi_line_output = 3
-line_length = 100
-atomic = true
-skip_gitignore = true
-case_sensitive = true
-known_heliclockter = 'heliclockter'
-sections = 'FUTURE,STDLIB,THIRDPARTY,HELICLOCKTER,FIRSTPARTY,LOCALFOLDER'
+[tool.ruff.lint]
+select = [
+  "E", # Enable all Pycodestyle error-level messages
+  "F", # Enable all Pyflakes messages
+  "I", # Enable all Isort messages
+  "PGH", # Enable https://github.com/pre-commit/pygrep-hooks, amongst others eval-used
+  "PIE", # Enable https://pypi.org/project/flake8-pie/, amongst others duplicate Enum values
+  "PLE", # Enable all Pylint error-level messages
+  "PLW", # Enable all Pylint warning-level messages
+  "RUF100", # Report unused noqa comments
+  "TCH", # Enable https://pypi.org/project/flake8-type-checking/
+  "UP", # Enable all pyupgrade messages
+  "W", # Enable all Pycodestyle warning-level messages.
+  "T20", # Disallow `print` statements.
+  "TID251", # Disallow banned imports, using flake8-tidy-imports.banned-api.
+]
+ignore = [
+    "UP007", # Needs a breaking change to drop Python 3.9 support
+]
+
+[tool.ruff.lint.isort]
+case-sensitive = true
+combine-as-imports = true
 
 [tool.pytest.ini_options]
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ line-length = 100
 output-format = "full"
 respect-gitignore = false
 show-fixes = true
-target-version = "py313"
 exclude = ["venv"]
 
 [tool.ruff.lint]
@@ -61,9 +60,6 @@ select = [
   "W", # Enable all Pycodestyle warning-level messages.
   "T20", # Disallow `print` statements.
   "TID251", # Disallow banned imports, using flake8-tidy-imports.banned-api.
-]
-ignore = [
-    "UP007", # Needs a breaking change to drop Python 3.9 support
 ]
 
 [tool.ruff.lint.isort]

--- a/src/heliclockter/__init__.py
+++ b/src/heliclockter/__init__.py
@@ -45,7 +45,7 @@ timedelta = _datetime.timedelta
 
 tz_local = cast("ZoneInfo", _datetime.datetime.now().astimezone().tzinfo)
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 
 DateTimeTzT = TypeVar("DateTimeTzT", bound="datetime_tz")

--- a/tests/assertion_test.py
+++ b/tests/assertion_test.py
@@ -10,8 +10,8 @@ from heliclockter import datetime_tz, timedelta, tz_local
 @parameterized.expand(
     [
         (datetime.datetime(2021, 1, 1, 10, tzinfo=tz_local),),
-        (datetime.datetime(2021, 1, 1, 10, tzinfo=ZoneInfo('CET')),),
-        (datetime.datetime(2021, 1, 1, 10, tzinfo=ZoneInfo('UTC')),),
+        (datetime.datetime(2021, 1, 1, 10, tzinfo=ZoneInfo("CET")),),
+        (datetime.datetime(2021, 1, 1, 10, tzinfo=ZoneInfo("UTC")),),
         (
             datetime.datetime(
                 2021, 1, 1, 10, tzinfo=datetime.timezone(datetime.timedelta(hours=-8))

--- a/tests/instantiation_test.py
+++ b/tests/instantiation_test.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from datetime import datetime, timezone, tzinfo
-from typing import Optional, Type, Union
+from typing import Union
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -15,10 +15,9 @@ from heliclockter import (
     timedelta,
     tz_local,
 )
-
 from tests.shared import datetime_cet
 
-DatetimeT = Union[Type[datetime_tz], Type[datetime_cet], Type[datetime_utc]]
+DatetimeT = Union[type[datetime_tz], type[datetime_cet], type[datetime_utc]]
 
 
 @parameterized.expand(
@@ -50,7 +49,7 @@ DatetimeT = Union[Type[datetime_tz], Type[datetime_cet], Type[datetime_utc]]
     ]
 )
 def test_from_datetime(
-    input_tz: Optional[tzinfo],
+    input_tz: Union[tzinfo, None],
     expected_dt_class: DatetimeT,
     expected_hour: int,
 ) -> None:
@@ -209,7 +208,7 @@ def test_deepcopy_datetime_tz() -> None:
     ]
 )
 def test_strptime(
-    dt_string: str, fmt: str, dt_class: Type[DateTimeTzT], expected_dt: DateTimeTzT
+    dt_string: str, fmt: str, dt_class: type[DateTimeTzT], expected_dt: DateTimeTzT
 ) -> None:
     assert dt_class.strptime(dt_string, fmt) == expected_dt
 
@@ -251,7 +250,7 @@ def test_fromtimestamp(timestamp: float, expected_dt: datetime_utc) -> None:
     ]
 )
 def test_future_and_past(
-    dt_class: Type[DateTimeTzT], days: int = 0, weeks: int = 0, tz: Optional[ZoneInfo] = None
+    dt_class: type[DateTimeTzT], days: int = 0, weeks: int = 0, tz: Union[ZoneInfo, None] = None
 ) -> None:
     delta = timedelta(days=days, weeks=weeks)
     dt_past = dt_class.past(days=days, weeks=weeks, tz=tz)

--- a/tests/instantiation_test.py
+++ b/tests/instantiation_test.py
@@ -23,23 +23,23 @@ DatetimeT = Union[type[datetime_tz], type[datetime_cet], type[datetime_utc]]
 @parameterized.expand(
     [
         # Tests for datetime_tz. Parsing datetime_tz from `datetime` should not modify hours.
-        (ZoneInfo('CET'), datetime_tz, 10),
+        (ZoneInfo("CET"), datetime_tz, 10),
         (timezone(timedelta(hours=1)), datetime_tz, 10),
-        (ZoneInfo('UTC'), datetime_tz, 10),
+        (ZoneInfo("UTC"), datetime_tz, 10),
         (timezone(timedelta(hours=-4)), datetime_tz, 10),
         (timezone(timedelta(hours=4)), datetime_tz, 10),
         # Tests for datetime_cet. Parsing datetime_cet from `datetime` should modify hours, if
         # the UTC offset of the `datetime` is not equal to that of the 'CET' timezone.
-        (ZoneInfo('CET'), datetime_cet, 10),
+        (ZoneInfo("CET"), datetime_cet, 10),
         (timezone(timedelta(hours=1)), datetime_cet, 10),
-        (ZoneInfo('UTC'), datetime_cet, 11),
+        (ZoneInfo("UTC"), datetime_cet, 11),
         (timezone(timedelta(hours=-4)), datetime_cet, 15),
         (timezone(timedelta(hours=4)), datetime_cet, 7),
         # Tests for datetime_utc. Parsing datetime_utc from `datetime` should modify hours, if
         # the timezone of the `datetime` is not UTC.
-        (ZoneInfo('CET'), datetime_utc, 9),
+        (ZoneInfo("CET"), datetime_utc, 9),
         (timezone(timedelta(hours=1)), datetime_utc, 9),
-        (ZoneInfo('UTC'), datetime_utc, 10),
+        (ZoneInfo("UTC"), datetime_utc, 10),
         (timezone(timedelta(hours=-4)), datetime_utc, 14),
         (timezone(timedelta(hours=4)), datetime_utc, 6),
         # Tests to ensure a naive datetime can be parsed as datetime_utc, and datetime_cet.
@@ -69,7 +69,7 @@ def test_datetime_tz_from_naive_datetime() -> None:
     # datetime_tz should not be able to parse from a naive datetime.datetime
     input_dt = datetime(year=2021, month=1, day=1, hour=10)
     with pytest.raises(
-        DatetimeTzError, match='Cannot create aware datetime from naive if no tz is assumed'
+        DatetimeTzError, match="Cannot create aware datetime from naive if no tz is assumed"
     ):
         datetime_tz.from_datetime(input_dt)
 
@@ -79,17 +79,17 @@ def test_datetime_tz_from_naive_datetime() -> None:
         (
             datetime_utc,
             10,
-            datetime_utc(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo("UTC")),
         ),
         (
             datetime_cet,
             10,
-            datetime_cet(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo('CET')),
+            datetime_cet(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo("CET")),
         ),
         (
             datetime_cet,
             11,
-            datetime_utc(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(year=2021, month=1, day=1, hour=10, tzinfo=ZoneInfo("UTC")),
         ),
     ]
 )
@@ -105,8 +105,8 @@ def test_datetime_tz_now() -> None:
     with pytest.raises(
         DatetimeTzError,
         match=(
-            'Must override assumed_timezone_for_timezone_naive_input '
-            'or give a timezone when calling now'
+            "Must override assumed_timezone_for_timezone_naive_input "
+            "or give a timezone when calling now"
         ),
     ):
         datetime_tz.now()
@@ -131,79 +131,79 @@ def test_deepcopy_datetime_tz() -> None:
     [
         # UTC naive tests
         (
-            '2021-01-10 09:00',
-            '%Y-%m-%d %H:%M',
+            "2021-01-10 09:00",
+            "%Y-%m-%d %H:%M",
             datetime_utc,
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
         ),
         (
-            '2021-01-10 09:00:00',
-            '%Y-%m-%d %H:%M:%S',
+            "2021-01-10 09:00:00",
+            "%Y-%m-%d %H:%M:%S",
             datetime_utc,
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
         ),
         (
-            '2021-01-10T09:00:00.000000',
-            '%Y-%m-%dT%H:%M:%S.%f',
+            "2021-01-10T09:00:00.000000",
+            "%Y-%m-%dT%H:%M:%S.%f",
             datetime_utc,
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
         ),
         # UTC aware tests
         (
-            '2021-01-10 09:00+00:00',
-            '%Y-%m-%d %H:%M%z',
+            "2021-01-10 09:00+00:00",
+            "%Y-%m-%d %H:%M%z",
             datetime_utc,
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
         ),
         (
-            '2021-01-10 09:00:00+00:00',
-            '%Y-%m-%d %H:%M:%S%z',
+            "2021-01-10 09:00:00+00:00",
+            "%Y-%m-%d %H:%M:%S%z",
             datetime_utc,
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
         ),
         (
-            '2021-01-10T09:00:00.000000+00:00',
-            '%Y-%m-%dT%H:%M:%S.%f%z',
+            "2021-01-10T09:00:00.000000+00:00",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
             datetime_utc,
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
         ),
         # CET tests
         (
-            '2021-01-10 09:00',
-            '%Y-%m-%d %H:%M',
+            "2021-01-10 09:00",
+            "%Y-%m-%d %H:%M",
             datetime_cet,
-            datetime_cet(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('CET')),
+            datetime_cet(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("CET")),
         ),
         (
-            '2021-01-10 09:00:00',
-            '%Y-%m-%d %H:%M:%S',
+            "2021-01-10 09:00:00",
+            "%Y-%m-%d %H:%M:%S",
             datetime_cet,
-            datetime_cet(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('CET')),
+            datetime_cet(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("CET")),
         ),
         (
-            '2021-01-10T09:00:00.000000',
-            '%Y-%m-%dT%H:%M:%S.%f',
+            "2021-01-10T09:00:00.000000",
+            "%Y-%m-%dT%H:%M:%S.%f",
             datetime_cet,
-            datetime_cet(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('CET')),
+            datetime_cet(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("CET")),
         ),
         # CET aware tests
         (
-            '2021-01-10 09:00+00:00',
-            '%Y-%m-%d %H:%M%z',
+            "2021-01-10 09:00+00:00",
+            "%Y-%m-%d %H:%M%z",
             datetime_cet,
-            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('CET')),
+            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("CET")),
         ),
         (
-            '2021-01-10 09:00:00+00:00',
-            '%Y-%m-%d %H:%M:%S%z',
+            "2021-01-10 09:00:00+00:00",
+            "%Y-%m-%d %H:%M:%S%z",
             datetime_cet,
-            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('CET')),
+            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("CET")),
         ),
         (
-            '2021-01-10T09:00:00.000000+00:00',
-            '%Y-%m-%dT%H:%M:%S.%f%z',
+            "2021-01-10T09:00:00.000000+00:00",
+            "%Y-%m-%dT%H:%M:%S.%f%z",
             datetime_cet,
-            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('CET')),
+            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("CET")),
         ),
     ]
 )
@@ -215,17 +215,17 @@ def test_strptime(
 
 def test_strptime_datetime_tz_naive_dt_string() -> None:
     with pytest.raises(
-        DatetimeTzError, match='Cannot create aware datetime from naive if no tz is assumed'
+        DatetimeTzError, match="Cannot create aware datetime from naive if no tz is assumed"
     ):
-        datetime_tz.strptime('2021-01-10 09:00', '%Y-%m-%d %H:%M')
+        datetime_tz.strptime("2021-01-10 09:00", "%Y-%m-%d %H:%M")
 
 
 @parameterized.expand(
     [
-        (1609491600.0, datetime_utc(2021, 1, 1, 9, 0, tzinfo=ZoneInfo('UTC'))),
-        (1625126400.0, datetime_utc(2021, 7, 1, 8, 0, tzinfo=ZoneInfo('UTC'))),
-        (1656663915.0, datetime_utc(2022, 7, 1, 8, 25, 15, tzinfo=ZoneInfo('UTC'))),
-        (1277972715.0, datetime_utc(2010, 7, 1, 8, 25, 15, tzinfo=ZoneInfo('UTC'))),
+        (1609491600.0, datetime_utc(2021, 1, 1, 9, 0, tzinfo=ZoneInfo("UTC"))),
+        (1625126400.0, datetime_utc(2021, 7, 1, 8, 0, tzinfo=ZoneInfo("UTC"))),
+        (1656663915.0, datetime_utc(2022, 7, 1, 8, 25, 15, tzinfo=ZoneInfo("UTC"))),
+        (1277972715.0, datetime_utc(2010, 7, 1, 8, 25, 15, tzinfo=ZoneInfo("UTC"))),
     ]
 )
 def test_fromtimestamp(timestamp: float, expected_dt: datetime_utc) -> None:
@@ -244,9 +244,9 @@ def test_fromtimestamp(timestamp: float, expected_dt: datetime_utc) -> None:
         (datetime_local, 2),
         (datetime_local, -2),
         (datetime_local, 0, 2),
-        (datetime_tz, 2, 0, ZoneInfo('EST')),
-        (datetime_tz, -2, 0, ZoneInfo('EST')),
-        (datetime_tz, 0, 2, ZoneInfo('EST')),
+        (datetime_tz, 2, 0, ZoneInfo("EST")),
+        (datetime_tz, -2, 0, ZoneInfo("EST")),
+        (datetime_tz, 0, 2, ZoneInfo("EST")),
     ]
 )
 def test_future_and_past(
@@ -263,8 +263,8 @@ def test_future_and_past(
 
 def test_future_and_past_no_tz() -> None:
     error_msg = (
-        'Must override assumed_timezone_for_timezone_naive_input '
-        'or give a timezone when calling now'
+        "Must override assumed_timezone_for_timezone_naive_input "
+        "or give a timezone when calling now"
     )
     with pytest.raises(DatetimeTzError, match=error_msg):
         datetime_tz.future(days=2)
@@ -276,7 +276,7 @@ def test_future_and_past_no_tz() -> None:
 @parameterized.expand([(0,), (1,)])
 def test_fold_tz(fold: int) -> None:
     dt = datetime_tz(2023, 10, 29, 2, 30, fold=fold, tzinfo=ZoneInfo("Europe/Berlin"))
-    iso = "2023-10-29T02:30:00+01:00" if fold == 1 else '2023-10-29T02:30:00+02:00'
+    iso = "2023-10-29T02:30:00+01:00" if fold == 1 else "2023-10-29T02:30:00+02:00"
     assert dt.isoformat() == iso
 
 

--- a/tests/mutation_test.py
+++ b/tests/mutation_test.py
@@ -4,8 +4,8 @@ from heliclockter import datetime_utc, timedelta
 
 
 def test_datetime_tz_subtraction() -> None:
-    dt_1 = datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC'))
-    dt_2 = datetime_utc(2020, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC'))
+    dt_1 = datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC"))
+    dt_2 = datetime_utc(2020, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC"))
 
     assert dt_1 - dt_2 == timedelta(days=366)
     assert dt_2 - dt_1 == timedelta(days=-366)

--- a/tests/pydantic_parsing_test.py
+++ b/tests/pydantic_parsing_test.py
@@ -7,7 +7,6 @@ from parameterized import parameterized  # type: ignore[import-untyped]
 from pydantic import BaseModel, ValidationError
 
 from heliclockter import DateTimeTzT, datetime_local, datetime_tz, datetime_utc, timedelta
-
 from tests.shared import datetime_cet
 
 

--- a/tests/pydantic_parsing_test.py
+++ b/tests/pydantic_parsing_test.py
@@ -38,67 +38,67 @@ TestModelT = Union[DatetimeTZModel, DatetimeUTCModel, DatetimeCETModel]
     [
         # UTC tests
         (
-            '2021-01-10T10:00:00',
-            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00",
+            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         (
-            '2021-01-10T10:00:00+04:00',
-            datetime_utc(2021, 1, 10, 6, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00+04:00",
+            datetime_utc(2021, 1, 10, 6, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         (
-            '2021-01-10T10:00:00+00:00',
-            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00+00:00",
+            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         (
-            '2021-01-10T10:00:00-04:00',
-            datetime_utc(2021, 1, 10, 14, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00-04:00",
+            datetime_utc(2021, 1, 10, 14, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         # TZ tests
         (
-            '2021-01-10T10:00:00+04:00',
+            "2021-01-10T10:00:00+04:00",
             datetime_tz(2021, 1, 10, 10, 0, tzinfo=timezone(timedelta(hours=4))),
             DatetimeTZModel,
         ),
         (
-            '2021-01-10T10:00:00-04:00',
+            "2021-01-10T10:00:00-04:00",
             datetime_tz(2021, 1, 10, 10, 0, tzinfo=timezone(timedelta(hours=-4))),
             DatetimeTZModel,
         ),
         # CET tests
         (
-            '2021-01-10T10:00:00',
-            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00",
+            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
         (
-            '2021-01-10T10:00:00+04:00',
-            datetime_cet(2021, 1, 10, 7, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00+04:00",
+            datetime_cet(2021, 1, 10, 7, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
         (
-            '2021-01-10T10:00:00+00:00',
-            datetime_cet(2021, 1, 10, 11, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00+00:00",
+            datetime_cet(2021, 1, 10, 11, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
         (
-            '2021-01-10T10:00:00-04:00',
-            datetime_cet(2021, 1, 10, 15, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00-04:00",
+            datetime_cet(2021, 1, 10, 15, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
     ]
 )
 def test_datetime_parsing(test_str: str, expectation: DateTimeTzT, model: TestModelT) -> None:
-    parsed_model = model.model_validate({'dt': test_str})
+    parsed_model = model.model_validate({"dt": test_str})
     assert isinstance(parsed_model.dt, type(expectation))
     assert parsed_model.dt == expectation
 
 
 def test_datetime_local_parsing() -> None:
-    parsed_model = DatetimeLocalModel.model_validate({'dt': '2021-01-10T10:00:00-04:00'})
+    parsed_model = DatetimeLocalModel.model_validate({"dt": "2021-01-10T10:00:00-04:00"})
     assert isinstance(parsed_model.dt, datetime_local)
 
 
@@ -115,12 +115,12 @@ def test_parse_datetime_utc_as_datetime_tz() -> None:
 
 def test_parse_datetime_tz_without_timezone() -> None:
     with pytest.raises(ValidationError):
-        DatetimeTZModel.model_validate({'dt': '2021-01-10T10:00:00'})
+        DatetimeTZModel.model_validate({"dt": "2021-01-10T10:00:00"})
 
 
 def test_parse_datetime_instance() -> None:
-    dt = datetime(2021, 1, 10, 10, 0, 0, tzinfo=ZoneInfo('UTC'))
-    DatetimeTZModel.model_validate({'dt': dt})
+    dt = datetime(2021, 1, 10, 10, 0, 0, tzinfo=ZoneInfo("UTC"))
+    DatetimeTZModel.model_validate({"dt": dt})
 
     parsed_tz_model = DatetimeTZModel(dt=dt)  # type: ignore[arg-type]
     assert isinstance(parsed_tz_model.dt, datetime_tz)

--- a/tests/pydantic_serialization_test.py
+++ b/tests/pydantic_serialization_test.py
@@ -10,6 +10,6 @@ class DatetimeTZModel(BaseModel):
 
 
 def test_pydantic_serialization() -> None:
-    obj = DatetimeTZModel(dt=datetime_tz(2021, 1, 10, 10, 0, tzinfo=ZoneInfo('UTC')))
+    obj = DatetimeTZModel(dt=datetime_tz(2021, 1, 10, 10, 0, tzinfo=ZoneInfo("UTC")))
 
     assert obj.model_dump_json() == '{"dt":"2021-01-10T10:00:00Z"}'

--- a/tests/pydantic_v1_parsing_test.py
+++ b/tests/pydantic_v1_parsing_test.py
@@ -38,67 +38,67 @@ TestModelT = Union[DatetimeTZModel, DatetimeUTCModel, DatetimeCETModel]
     [
         # UTC tests
         (
-            '2021-01-10T10:00:00',
-            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00",
+            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         (
-            '2021-01-10T10:00:00+04:00',
-            datetime_utc(2021, 1, 10, 6, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00+04:00",
+            datetime_utc(2021, 1, 10, 6, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         (
-            '2021-01-10T10:00:00+00:00',
-            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00+00:00",
+            datetime_utc(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         (
-            '2021-01-10T10:00:00-04:00',
-            datetime_utc(2021, 1, 10, 14, 00, 00, tzinfo=ZoneInfo('UTC')),
+            "2021-01-10T10:00:00-04:00",
+            datetime_utc(2021, 1, 10, 14, 00, 00, tzinfo=ZoneInfo("UTC")),
             DatetimeUTCModel,
         ),
         # TZ tests
         (
-            '2021-01-10T10:00:00+04:00',
+            "2021-01-10T10:00:00+04:00",
             datetime_tz(2021, 1, 10, 10, 0, tzinfo=timezone(timedelta(hours=4))),
             DatetimeTZModel,
         ),
         (
-            '2021-01-10T10:00:00-04:00',
+            "2021-01-10T10:00:00-04:00",
             datetime_tz(2021, 1, 10, 10, 0, tzinfo=timezone(timedelta(hours=-4))),
             DatetimeTZModel,
         ),
         # CET tests
         (
-            '2021-01-10T10:00:00',
-            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00",
+            datetime_cet(2021, 1, 10, 10, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
         (
-            '2021-01-10T10:00:00+04:00',
-            datetime_cet(2021, 1, 10, 7, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00+04:00",
+            datetime_cet(2021, 1, 10, 7, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
         (
-            '2021-01-10T10:00:00+00:00',
-            datetime_cet(2021, 1, 10, 11, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00+00:00",
+            datetime_cet(2021, 1, 10, 11, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
         (
-            '2021-01-10T10:00:00-04:00',
-            datetime_cet(2021, 1, 10, 15, 00, 00, tzinfo=ZoneInfo('CET')),
+            "2021-01-10T10:00:00-04:00",
+            datetime_cet(2021, 1, 10, 15, 00, 00, tzinfo=ZoneInfo("CET")),
             DatetimeCETModel,
         ),
     ]
 )
 def test_datetime_parsing(test_str: str, expectation: DateTimeTzT, model: TestModelT) -> None:
-    parsed_model = model.parse_obj({'dt': test_str})
+    parsed_model = model.parse_obj({"dt": test_str})
     assert isinstance(parsed_model.dt, type(expectation))
     assert parsed_model.dt == expectation
 
 
 def test_datetime_local_parsing() -> None:
-    parsed_model = DatetimeLocalModel.parse_obj({'dt': '2021-01-10T10:00:00-04:00'})
+    parsed_model = DatetimeLocalModel.parse_obj({"dt": "2021-01-10T10:00:00-04:00"})
     assert isinstance(parsed_model.dt, datetime_local)
 
 
@@ -115,12 +115,12 @@ def test_parse_datetime_utc_as_datetime_tz() -> None:
 
 def test_parse_datetime_tz_without_timezone() -> None:
     with pytest.raises(ValidationError):
-        DatetimeTZModel.parse_obj({'dt': '2021-01-10T10:00:00'})
+        DatetimeTZModel.parse_obj({"dt": "2021-01-10T10:00:00"})
 
 
 def test_parse_datetime_instance() -> None:
-    dt = datetime(2021, 1, 10, 10, 0, 0, tzinfo=ZoneInfo('UTC'))
-    DatetimeTZModel.parse_obj({'dt': dt})
+    dt = datetime(2021, 1, 10, 10, 0, 0, tzinfo=ZoneInfo("UTC"))
+    DatetimeTZModel.parse_obj({"dt": dt})
 
     parsed_tz_model = DatetimeTZModel(dt=dt)  # type: ignore[arg-type]
     assert isinstance(parsed_tz_model.dt, datetime_tz)

--- a/tests/pydantic_v1_parsing_test.py
+++ b/tests/pydantic_v1_parsing_test.py
@@ -7,7 +7,6 @@ from parameterized import parameterized  # type: ignore[import-untyped]
 from pydantic.v1 import BaseModel, ValidationError
 
 from heliclockter import DateTimeTzT, datetime_local, datetime_tz, datetime_utc, timedelta
-
 from tests.shared import datetime_cet
 
 

--- a/tests/serialization_test.py
+++ b/tests/serialization_test.py
@@ -8,29 +8,29 @@ from heliclockter import datetime_tz, datetime_utc
 @parameterized.expand(
     [
         (
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
-            '%Y-%m-%d',
-            '2021-01-10',
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
+            "%Y-%m-%d",
+            "2021-01-10",
         ),
         (
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
-            '%Y-%m-%d %H:%M',
-            '2021-01-10 09:00',
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
+            "%Y-%m-%d %H:%M",
+            "2021-01-10 09:00",
         ),
         (
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
-            '%Y-%m-%d %H:%M:%S',
-            '2021-01-10 09:00:00',
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
+            "%Y-%m-%d %H:%M:%S",
+            "2021-01-10 09:00:00",
         ),
         (
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
-            '%Y-%m-%d %H:%M:%SZ',
-            '2021-01-10 09:00:00Z',
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
+            "%Y-%m-%d %H:%M:%SZ",
+            "2021-01-10 09:00:00Z",
         ),
         (
-            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo('UTC')),
-            '%Y-%m-%dT%H:%M:%S.%f',
-            '2021-01-10T09:00:00.000000',
+            datetime_utc(2021, 1, 10, 9, 00, 00, tzinfo=ZoneInfo("UTC")),
+            "%Y-%m-%dT%H:%M:%S.%f",
+            "2021-01-10T09:00:00.000000",
         ),
     ]
 )

--- a/tests/shared.py
+++ b/tests/shared.py
@@ -15,4 +15,4 @@ class datetime_cet(datetime_tz):
     A `datetime_cet` is a `datetime_tz` but which is guaranteed to be in the 'CET' timezone.
     """
 
-    assumed_timezone_for_timezone_naive_input = ZoneInfo('CET')
+    assumed_timezone_for_timezone_naive_input = ZoneInfo("CET")


### PR DESCRIPTION
Replaces black with Ruff. Ruff is faster and has more features than Black.
We need to ignore https://docs.astral.sh/ruff/rules/non-pep604-annotation-union/ to keep support for Python 3.9