### PR TITLE
Drop Python 3.9 support, bump to 2.0.0

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -19,11 +19,6 @@ blocks:
           - "python3.10 -m pip install -e .[all]"
 
       jobs:
-        - name: "Unit tests 3.9"
-          commands:
-            # Semaphore does not have python3.11, so we run the tests using a Dockerfile
-            - "sudo docker build --build-arg PYTHON_VERSION=3.9.13 -t py309 . && sudo docker run py309"
-
         - name: "Unit tests 3.10"
           commands:
             - "export PUBLISH_JUNIT_REPORT=true" # Export junit report from this job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+2.0.0
+-----
+
+Released 2025-08-01.
+
+**Breaking changes**:
+
+- Dropped support for Python 3.9
+
+Release highlights:
+
+- Dropped support for Python 3.9 to allow more modern Python syntax
+
 1.3.2
 -----
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = 'setuptools.build_meta'
 name = 'heliclockter'
 description = 'A robust way of dealing with datetimes in python by ensuring all datetimes are timezone aware at runtime.'
 readme = 'README.md'
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 keywords = ['datetime', 'heliclockter', 'timezone', 'timezones', 'tz', 'tzinfo']
 license = {file = 'LICENSE'}
 classifiers = [
@@ -15,7 +15,6 @@ classifiers = [
     'Natural Language :: English',
     'Operating System :: Unix',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',

--- a/src/heliclockter/__init__.py
+++ b/src/heliclockter/__init__.py
@@ -1,14 +1,7 @@
 from __future__ import annotations
 
 import datetime as _datetime
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    ClassVar,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, ClassVar, TypeVar, cast
 from zoneinfo import ZoneInfo
 
 if TYPE_CHECKING:
@@ -49,7 +42,7 @@ __version__ = "1.3.2"
 
 
 DateTimeTzT = TypeVar("DateTimeTzT", bound="datetime_tz")
-IntFloat = Union[int, float]
+IntFloat = int | float
 
 
 class DatetimeTzError(ValueError):

--- a/tests/instantiation_test.py
+++ b/tests/instantiation_test.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from datetime import datetime, timezone, tzinfo
-from typing import Union
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -17,7 +16,7 @@ from heliclockter import (
 )
 from tests.shared import datetime_cet
 
-DatetimeT = Union[type[datetime_tz], type[datetime_cet], type[datetime_utc]]
+DatetimeT = type[datetime_tz] | type[datetime_cet] | type[datetime_utc]
 
 
 @parameterized.expand(
@@ -49,7 +48,7 @@ DatetimeT = Union[type[datetime_tz], type[datetime_cet], type[datetime_utc]]
     ]
 )
 def test_from_datetime(
-    input_tz: Union[tzinfo, None],
+    input_tz: tzinfo | None,
     expected_dt_class: DatetimeT,
     expected_hour: int,
 ) -> None:
@@ -250,7 +249,7 @@ def test_fromtimestamp(timestamp: float, expected_dt: datetime_utc) -> None:
     ]
 )
 def test_future_and_past(
-    dt_class: type[DateTimeTzT], days: int = 0, weeks: int = 0, tz: Union[ZoneInfo, None] = None
+    dt_class: type[DateTimeTzT], days: int = 0, weeks: int = 0, tz: ZoneInfo | None = None
 ) -> None:
     delta = timedelta(days=days, weeks=weeks)
     dt_past = dt_class.past(days=days, weeks=weeks, tz=tz)

--- a/tests/pydantic_parsing_test.py
+++ b/tests/pydantic_parsing_test.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from typing import Union
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -31,7 +30,7 @@ class DatetimeDefaultObject(BaseModel):
     dt: str = datetime_utc.future(days=120).isoformat()
 
 
-TestModelT = Union[DatetimeTZModel, DatetimeUTCModel, DatetimeCETModel]
+TestModelT = DatetimeTZModel | DatetimeUTCModel | DatetimeCETModel
 
 
 @parameterized.expand(

--- a/tests/pydantic_v1_parsing_test.py
+++ b/tests/pydantic_v1_parsing_test.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from typing import Union
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -31,7 +30,7 @@ class DatetimeDefaultObject(BaseModel):
     dt: str = datetime_utc.future(days=120).isoformat()
 
 
-TestModelT = Union[DatetimeTZModel, DatetimeUTCModel, DatetimeCETModel]
+TestModelT = DatetimeTZModel | DatetimeUTCModel | DatetimeCETModel
 
 
 @parameterized.expand(


### PR DESCRIPTION
Python 3.9 is reaching end of life and won't receive security updates anymore: https://devguide.python.org/versions/
Dropping it also allows Ruff to use more modern syntax.
This is a breaking change and therefore we create the 2.0.0 version of heliclockter in this PR.